### PR TITLE
Force funty version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ arbitrary = { version="1.0", features=["derive"] }
 arbitrary-wrappers = { git = "ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git" }
 ark-serialize = { version = "0.3.0", features = ["derive"] }
 commit = { git = "ssh://git@github.com/SpectrumXYZ/commit.git", rev = "f48cd52c59755eade0605111826eef3df6abdcf8" }
+funty = "=1.1.0"
 itertools = "0.10.1"
 jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "fd1de050c214584a296a11f366846a53a316c4d4" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
`reef` failed to compile locally due to conflict `funty` versions. Forcing it to be `1.1.0` to fix the error.