### PR TITLE
Update jf-aap and arbitrary-wrappers versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 arbitrary = { version="1.0", features=["derive"] }
-arbitrary-wrappers = { git = "ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git", branch = "keyao-change-dep" }
+arbitrary-wrappers = { git = "ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git", rev = "bd84e90d131bdc4418a6c96543cb1003db1dd73b" }
 ark-serialize = { version = "0.3.0", features = ["derive"] }
 commit = { git = "ssh://git@github.com/SpectrumXYZ/commit.git", rev = "f48cd52c59755eade0605111826eef3df6abdcf8" }
 funty = "=1.1.0"


### PR DESCRIPTION
Depends on: [SpectrumXYZ/jellyfish-apps#89](https://github.com/SpectrumXYZ/jellyfish-apps/pull/89), https://github.com/SpectrumXYZ/arbitrary-wrappers/pull/2.