### PR TITLE
Allow validation to take auxiliary proof in addition to a block.

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -228,8 +228,12 @@ pub trait Validator:
     /// Blocks applied by this validator.
     type Block: Block;
 
+    /// Additional data required to authenticate a committed block, not contained in the block
+    /// itself.
+    type Proof: Clone + Debug + Serialize + DeserializeOwned + Send + Sync;
+
     /// The number of blocks this validator has applied.
-    fn now(&self) -> u64;
+    fn block_height(&self) -> u64;
 
     /// The commitment to the current state of the validator.
     fn commit(&self) -> Self::StateCommitment;
@@ -249,6 +253,7 @@ pub trait Validator:
     fn validate_and_apply(
         &mut self,
         block: Self::Block,
+        proof: Self::Proof,
     ) -> Result<(Vec<u64>, MerkleTree), <Self::Block as Block>::Error>;
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,6 +19,8 @@ pub type Validator<L> = <L as traits::Ledger>::Validator;
 pub type StateCommitment<L> = <Validator<L> as traits::Validator>::StateCommitment;
 /// A block of transactions that can be applied to a ledger `L`.
 pub type Block<L> = <Validator<L> as traits::Validator>::Block;
+/// A proof used to authenticate a committed block in a ledger `L`.
+pub type BlockProof<L> = <Validator<L> as traits::Validator>::Proof;
 /// An error that can occur while validating transitions of a ledger `L`.
 pub type ValidationError<L> = <Block<L> as traits::Block>::Error;
 /// A transaction that can be applied to a ledger `L`.


### PR DESCRIPTION
For now, this will be used to pass in the view number in Espresso validation. Later, it can also be used to validate QCs.